### PR TITLE
Fixed quite a bunch of issues with the old depot processing + more

### DIFF
--- a/DeveLanCacheUI_Backend/Program.cs
+++ b/DeveLanCacheUI_Backend/Program.cs
@@ -84,8 +84,8 @@ namespace DeveLanCacheUI_Backend
             }
             else
             {
-                builder.Services.AddHostedService<SteamDepotEnricherHostedService>();
                 builder.Services.AddHostedService<SteamDepotDownloaderHostedService>();
+                builder.Services.AddSingleton<SteamDepotEnricherHostedService>();
                 builder.Services.AddSingleton<ISteamAppObtainerService, OriginalSteamAppObtainerService>();
             }
 

--- a/DeveLanCacheUI_Backend/Services/OriginalDepotEnricher/SteamDepotEnricherHostedService.cs
+++ b/DeveLanCacheUI_Backend/Services/OriginalDepotEnricher/SteamDepotEnricherHostedService.cs
@@ -1,6 +1,6 @@
 ﻿namespace DeveLanCacheUI_Backend.Services.OriginalDepotEnricher
 {
-    public class SteamDepotEnricherHostedService : BackgroundService
+    public class SteamDepotEnricherHostedService
     {
         public IServiceProvider Services { get; }
 
@@ -16,157 +16,113 @@
             _logger = logger;
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        public async Task GoProcess(Version depotFileVersion, byte[] downloadedDepotFile, CancellationToken stoppingToken)
         {
-            await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
+            _logger.LogInformation("Processing depot file with version {DepotFileVersion}", depotFileVersion);
 
-            await GoRun(stoppingToken);
-        }
+            var desiredSteamAppToDepots = new List<SteamDepotEnricherCSVModel>();
+            //var depotToAppDict = new Dictionary<uint, uint>();
 
-
-        private async Task GoRun(CancellationToken stoppingToken)
-        {
-            var deveLanCacheUIDataDirectory = _deveLanCacheConfiguration.DeveLanCacheUIDataDirectory;
-            if (string.IsNullOrWhiteSpace(deveLanCacheUIDataDirectory))
+            using (var reader = new StreamReader(new MemoryStream(downloadedDepotFile)))
             {
-                deveLanCacheUIDataDirectory = Directory.GetCurrentDirectory();
-            }
+                string? line;
 
-            var depotFileDirectory = Path.Combine(deveLanCacheUIDataDirectory, "depotdir");
-
-            _logger.LogInformation("Watching directory: '{DepotFileDirectory}' for any .CSV files to update our Depot database...", depotFileDirectory);
-
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                if (Directory.Exists(depotFileDirectory))
+                while ((line = reader.ReadLine()) != null)
                 {
-                    var firstFile = Directory.GetFiles(depotFileDirectory).Where(t => Path.GetExtension(t).Equals(".csv", StringComparison.OrdinalIgnoreCase)).FirstOrDefault();
+                    var values = line.Split(';');
 
-                    if (firstFile != null)
+                    if (values.Length < 3)
                     {
-                        Console.WriteLine($"Found .CSV file to update our Depots Database: {firstFile}");
-
-
-                        var curFileSize = new FileInfo(firstFile).Length;
-                        Console.WriteLine($"Waiting for file size to not increase anymore (as in, the copy is done). Current Size: {curFileSize}");
-
-                        var fileSizeTimer = Stopwatch.StartNew();
-
-                        while (fileSizeTimer.Elapsed.TotalSeconds < 5)
-                        {
-                            var newFileSize = new FileInfo(firstFile).Length;
-                            if (curFileSize != newFileSize)
-                            {
-                                _logger.LogInformation("File size has increased, waiting 5 more seconds... from: {OldSize} to {NewSize}", curFileSize, newFileSize);
-                                curFileSize = newFileSize;
-                                fileSizeTimer.Restart();
-                            }
-                            else
-                            {
-                                _logger.LogInformation("File size equal for {Elapsed}", fileSizeTimer.Elapsed);
-                            }
-                            await Task.Delay(1000);
-                        }
-
-                        var desiredSteamAppToDepots = new List<SteamDepotEnricherCSVModel>();
-                        //var depotToAppDict = new Dictionary<uint, uint>();
-
-                        try
-                        {
-                            using (var reader = new StreamReader(firstFile))
-                            {
-                                string? line;
-
-                                while ((line = reader.ReadLine()) != null)
-                                {
-                                    var values = line.Split(';');
-
-                                    if (values.Length < 3)
-                                    {
-                                        //Console.WriteLine("Warning: Line does not contain sufficient data, skipping");
-                                        continue;
-                                    }
-
-                                    bool appIdParsed = uint.TryParse(values[0], out uint appId);
-                                    var appName = values[1];
-                                    bool depotIdParsed = uint.TryParse(values[2], out uint depotId);
-
-                                    if (!appIdParsed || !depotIdParsed)
-                                    {
-                                        //Console.WriteLine("Warning: AppId or DepotId could not be parsed, skipping");
-                                        continue;
-                                    }
-
-                                    //create csv model
-                                    var csvModel = new SteamDepotEnricherCSVModel
-                                    {
-                                        SteamAppId = appId,
-                                        SteamAppName = appName,
-                                        SteamDepotId = depotId
-                                    };
-
-                                    desiredSteamAppToDepots.Add(csvModel);
-                                }
-                            }
-
-                            Console.WriteLine($"Depot File {firstFile} read. Adding {desiredSteamAppToDepots.Count} entries to db...");
-
-
-                            desiredSteamAppToDepots = desiredSteamAppToDepots.DistinctBy(t => new { t.SteamAppId, t.SteamDepotId }).ToList();
-
-                            var retryPolicy = Policy
-                                .Handle<DbUpdateException>()
-                                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
-                                (exception, timeSpan, context) =>
-                                {
-                                    _logger.LogWarning("An error occurred while trying to save changes: {Message}", exception.Message);
-                                });
-
-                            //Batch operations in groups of 1000
-                            for (int i = 0; i < desiredSteamAppToDepots.Count; i += 1000)
-                            {
-                                await retryPolicy.ExecuteAsync(async () =>
-                                {
-                                    await using (var scope = Services.CreateAsyncScope())
-                                    {
-                                        using var dbContext = scope.ServiceProvider.GetRequiredService<DeveLanCacheUIDbContext>();
-                                        var currentBatch = desiredSteamAppToDepots.Skip(i).Take(1000).ToList();
-                                        int newDepots = 0;
-                                        foreach (var depot in currentBatch)
-                                        {
-                                            // Insert or update using Polly's retry policy
-                                            var dbDepot = await dbContext.SteamDepots.FirstOrDefaultAsync(d => d.SteamDepotId == depot.SteamDepotId && d.SteamAppId == depot.SteamAppId);
-                                            if (dbDepot == null)
-                                            {
-                                                //Depot does not exist, create it
-                                                dbDepot = new DbSteamDepot { SteamAppId = depot.SteamAppId, SteamDepotId = depot.SteamDepotId };
-                                                dbContext.SteamDepots.Add(dbDepot);
-                                                newDepots++;
-                                            }
-                                        }
-                                        //Save changes
-                                        await dbContext.SaveChangesAsync();
-                                        _logger.LogInformation($"Depots Processed: {i + currentBatch.Count}/{desiredSteamAppToDepots.Count}. Updated {currentBatch.Count - newDepots}, New {newDepots}");
-                                    }
-                                });
-                            }
-
-                            var processedDirectoryPath = Path.Combine(depotFileDirectory, "processed");
-                            Directory.CreateDirectory(processedDirectoryPath);
-                            var newFileName = Path.GetFileNameWithoutExtension(firstFile) + "_" + DateTime.Now.ToString("yyyy-dd-M--HH-mm-ss") + Path.GetExtension(firstFile);
-                            var newFilePath = Path.Combine(processedDirectoryPath, newFileName);
-                            File.Move(firstFile, newFilePath);
-                            Console.WriteLine($"File {firstFile} moved to {newFilePath}");
-                        }
-                        catch (IOException ex)
-                        {
-                            _logger.LogWarning("IO Exception while reading/writing file. This could be because file is in use. Retrying...");
-                        }
+                        //Console.WriteLine("Warning: Line does not contain sufficient data, skipping");
+                        continue;
                     }
+
+                    bool appIdParsed = uint.TryParse(values[0], out uint appId);
+                    var appName = values[1];
+                    bool depotIdParsed = uint.TryParse(values[2], out uint depotId);
+
+                    if (!appIdParsed || !depotIdParsed)
+                    {
+                        //Console.WriteLine("Warning: AppId or DepotId could not be parsed, skipping");
+                        continue;
+                    }
+
+                    //create csv model
+                    var csvModel = new SteamDepotEnricherCSVModel
+                    {
+                        SteamAppId = appId,
+                        SteamAppName = appName,
+                        SteamDepotId = depotId
+                    };
+
+                    desiredSteamAppToDepots.Add(csvModel);
                 }
-                await Task.Delay(1000);
             }
 
+            _logger.LogInformation("Depot data read. Adding {DepotCount} entries to db...", desiredSteamAppToDepots.Count);
+
+            desiredSteamAppToDepots = desiredSteamAppToDepots.DistinctBy(t => new { t.SteamAppId, t.SteamDepotId }).ToList();
+
+            var retryPolicy = Policy
+                .Handle<DbUpdateException>()
+                .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                (exception, timeSpan, context) =>
+                {
+                    _logger.LogWarning("An error occurred while trying to save changes: {Message}", exception.Message);
+                });
+
+            //Batch operations in groups of 1000
+            for (int i = 0; i < desiredSteamAppToDepots.Count; i += 1000)
+            {
+                await retryPolicy.ExecuteAsync(async () =>
+                {
+                    await using (var scope = Services.CreateAsyncScope())
+                    {
+                        using var dbContext = scope.ServiceProvider.GetRequiredService<DeveLanCacheUIDbContext>();
+                        var currentBatch = desiredSteamAppToDepots.Skip(i).Take(1000).ToList();
+                        int newDepots = 0;
+                        foreach (var depot in currentBatch)
+                        {
+                            // Insert or update using Polly's retry policy
+                            var dbDepot = await dbContext.SteamDepots.FirstOrDefaultAsync(d => d.SteamDepotId == depot.SteamDepotId && d.SteamAppId == depot.SteamAppId);
+                            if (dbDepot == null)
+                            {
+                                //Depot does not exist, create it
+                                dbDepot = new DbSteamDepot { SteamAppId = depot.SteamAppId, SteamDepotId = depot.SteamDepotId };
+                                dbContext.SteamDepots.Add(dbDepot);
+                                newDepots++;
+                            }
+                        }
+                        //Save changes
+                        await dbContext.SaveChangesAsync();
+                        _logger.LogInformation($"Depots Processed: {i + currentBatch.Count}/{desiredSteamAppToDepots.Count}. Updated {currentBatch.Count - newDepots}, New {newDepots}");
+                    }
+                });
+            }
+
+            _logger.LogInformation("Depot data processing completed. Total entries added: {TotalEntries}", desiredSteamAppToDepots.Count);
+
+            await using (var scope = Services.CreateAsyncScope())
+            {
+                using var dbContext = scope.ServiceProvider.GetRequiredService<DeveLanCacheUIDbContext>();
+                var foundSetting = await dbContext.Settings.FirstOrDefaultAsync(t => t.Key == DbSetting.SettingKey_DepotVersion);
+                if (foundSetting == null || foundSetting.Value == null)
+                {
+                    foundSetting = new DbSetting()
+                    {
+                        Key = DbSetting.SettingKey_DepotVersion,
+                        Value = depotFileVersion.ToString()
+                    };
+                    dbContext.Settings.Add(foundSetting);
+                }
+                else
+                {
+                    foundSetting.Value = depotFileVersion.ToString();
+                }
+                await dbContext.SaveChangesAsync();
+            }
+
+            _logger.LogInformation("Depot file processing completed successfully. Version {DepotFileVersion} saved to database.", depotFileVersion);
         }
     }
 }

--- a/DeveLanCacheUI_Backend/Services/SteamAppInfoService.cs
+++ b/DeveLanCacheUI_Backend/Services/SteamAppInfoService.cs
@@ -132,7 +132,11 @@
                     var item = dbContext.Settings.FirstOrDefault(t => t.Key == DbSetting.SettingKey_SteamChangeNumber);
                     if (item == null)
                     {
-                        item = new DbSetting { Key = DbSetting.SettingKey_SteamChangeNumber, Value = _currentChangeNumber.ToString() };
+                        item = new DbSetting
+                        {
+                            Key = DbSetting.SettingKey_SteamChangeNumber,
+                            Value = _currentChangeNumber.ToString()
+                        };
                         dbContext.Settings.Add(item);
                     }
                     else


### PR DESCRIPTION
* Don't store depots on disk anymore but rather just process them in memory
* Fixed an issue where I would overwrite another setting to store the version. This caused 2 issues:
  * An issue where it redownloaded the depot file every hour
  * Issues when you enabled `Feature_SkipLinesBasedOnBytesRead` and disabled `Feature_DirectSteamIntegration`.